### PR TITLE
ci(Mergify): configuration update

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -19,8 +19,4 @@ pull_request_rules:
       label:
         add:
           - enhancement
-queue_rules:
-  - queue_branch_merge_method: fast-forward
-    allow_queue_branch_edit: true
-    update_method: merge
-    name: default
+queue_rules: []


### PR DESCRIPTION
This change has been made by @MH0386 from the Mergify Queue Rule Configurator.

## Summary by Sourcery

CI:
- Remove default queue_rules block in .github/mergify.yml to disable preconfigured merging rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Mergify configuration by removing all existing queue rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->