### PR TITLE
Multi-stage dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,11 @@ USER nonroot
 
 WORKDIR /home/nonroot
 
+RUN mkdir /home/nonroot/bin
+
 COPY --from=builder --chown=nonroot:nonroot --chmod=775 /home/nonroot/.local/bin/vocalizr /home/nonroot/bin/vocalizr
+
+RUN chmod +x /home/nonroot/bin/vocalizr
 
 EXPOSE ${GRADIO_SERVER_PORT}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,5 @@
 FROM cgr.dev/chainguard/wolfi-base:latest@sha256:952010d4b1cf8dfb420ff86d66eb7ec78468b9cf60366dc8939f496322c458d8 AS builder
 
-ENV UV_LINK_MODE=copy \
-    UV_COMPILE_BYTECODE=1 \
-    UV_PYTHON_PREFERENCE=only-managed \
-    UV_PYTHON_INSTALL_DIR=/home/nonroot/python
-
 COPY --from=ghcr.io/astral-sh/uv:latest@sha256:5778d479c0fd7995fedd44614570f38a9d849256851f2786c451c220d7bd8ccd \
     /uv /uvx /usr/bin/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,21 @@
-FROM cgr.dev/chainguard/wolfi-base:latest@sha256:952010d4b1cf8dfb420ff86d66eb7ec78468b9cf60366dc8939f496322c458d8 AS builder
+FROM cgr.dev/chainguard/wolfi-base:latest@sha256:952010d4b1cf8dfb420ff86d66eb7ec78468b9cf60366dc8939f496322c458d8
+
+ENV GRADIO_SERVER_PORT=7860 \
+    GRADIO_SERVER_NAME=0.0.0.0 \
+    HF_HOME=/home/nonroot/hf \
+    PATH=/home/nonroot/.local/bin:$PATH
 
 COPY --from=ghcr.io/astral-sh/uv:latest@sha256:5778d479c0fd7995fedd44614570f38a9d849256851f2786c451c220d7bd8ccd \
     /uv /uvx /usr/bin/
 
-RUN apk add --no-cache build-base git
-
-USER nonroot
-
-RUN uv tool install git+https://github.com/AlphaSphereDotAI/vocalizr
-
-FROM cgr.dev/chainguard/wolfi-base:latest@sha256:952010d4b1cf8dfb420ff86d66eb7ec78468b9cf60366dc8939f496322c458d8 AS production
-
-ENV GRADIO_SERVER_PORT=7860 \
-    GRADIO_SERVER_NAME=0.0.0.0 \
-    HF_HOME=/home/nonroot/hf
-
-RUN apk add --no-cache curl libstdc++
+RUN apk add --no-cache libstdc++ git curl gcc
 
 USER nonroot
 
 WORKDIR /home/nonroot
 
-COPY --from=builder /home/nonroot/.local/bin/vocalizr /usr/bin/
+RUN uv tool install --no-cache git+https://github.com/AlphaSphereDotAI/vocalizr
 
 EXPOSE ${GRADIO_SERVER_PORT}
 
-CMD ["vocalizr"]
+CMD ["uvx", "vocalizr"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,9 @@ USER nonroot
 
 WORKDIR /home/nonroot
 
-COPY --from=builder /home/nonroot/.local/bin/vocalizr /usr/bin/
+RUN mkdir -p /home/nonroot/bin
+COPY --from=builder /home/nonroot/.local/bin/vocalizr /home/nonroot/bin/
+ENV PATH="/home/nonroot/bin:${PATH}"
 
 EXPOSE ${GRADIO_SERVER_PORT}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,28 @@
-FROM cgr.dev/chainguard/wolfi-base:latest@sha256:952010d4b1cf8dfb420ff86d66eb7ec78468b9cf60366dc8939f496322c458d8
-
-ENV GRADIO_SERVER_PORT=7860 \
-    GRADIO_SERVER_NAME=0.0.0.0 \
-    HF_HOME=/home/nonroot/hf \
-    PATH=/home/nonroot/.local/bin:$PATH
+FROM cgr.dev/chainguard/wolfi-base:latest@sha256:952010d4b1cf8dfb420ff86d66eb7ec78468b9cf60366dc8939f496322c458d8 AS builder
 
 COPY --from=ghcr.io/astral-sh/uv:latest@sha256:5778d479c0fd7995fedd44614570f38a9d849256851f2786c451c220d7bd8ccd \
     /uv /uvx /usr/bin/
 
-RUN apk add --no-cache libstdc++ git curl gcc
+RUN apk add --no-cache build-base git
+
+USER nonroot
+
+RUN uv tool install git+https://github.com/AlphaSphereDotAI/vocalizr
+
+FROM cgr.dev/chainguard/wolfi-base:latest@sha256:952010d4b1cf8dfb420ff86d66eb7ec78468b9cf60366dc8939f496322c458d8 AS production
+
+ENV GRADIO_SERVER_PORT=7860 \
+    GRADIO_SERVER_NAME=0.0.0.0 \
+    HF_HOME=/home/nonroot/hf
+
+RUN apk add --no-cache curl libstdc++
 
 USER nonroot
 
 WORKDIR /home/nonroot
 
-RUN uv tool install --no-cache git+https://github.com/AlphaSphereDotAI/vocalizr
+COPY --from=builder /home/nonroot/.local/bin/vocalizr /usr/bin/
 
 EXPOSE ${GRADIO_SERVER_PORT}
 
-CMD ["uvx", "vocalizr"]
+CMD ["vocalizr"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/wolfi-base:latest AS builder
+FROM cgr.dev/chainguard/wolfi-base:latest@sha256:952010d4b1cf8dfb420ff86d66eb7ec78468b9cf60366dc8939f496322c458d8 AS builder
 
 ENV UV_LINK_MODE=copy \
     UV_COMPILE_BYTECODE=1 \
@@ -16,7 +16,7 @@ WORKDIR /home/nonroot/app
 
 RUN uv tool install git+https://github.com/AlphaSphereDotAI/vocalizr
 
-FROM cgr.dev/chainguard/wolfi-base:latest AS production
+FROM cgr.dev/chainguard/wolfi-base:latest@sha256:952010d4b1cf8dfb420ff86d66eb7ec78468b9cf60366dc8939f496322c458d8 AS production
 
 ENV GRADIO_SERVER_PORT=7860 \
     GRADIO_SERVER_NAME=0.0.0.0 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ USER nonroot
 
 WORKDIR /home/nonroot
 
-COPY --from=builder --chown=nonroot:nonroot --chmod=775 /home/nonroot/.local/bin/vocalizr /home/nonroot/bin/
+COPY --from=builder --chown=nonroot:nonroot --chmod=775 /home/nonroot/.local/bin/vocalizr /home/nonroot/bin/vocalizr
 
 EXPOSE ${GRADIO_SERVER_PORT}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,11 +23,7 @@ USER nonroot
 
 WORKDIR /home/nonroot
 
-RUN mkdir /home/nonroot/bin
-
-COPY --from=builder --chown=nonroot:nonroot --chmod=775 /home/nonroot/.local/bin/vocalizr /home/nonroot/bin/vocalizr
-
-RUN chmod +x /home/nonroot/bin/vocalizr
+COPY --from=builder --chown=nonroot:nonroot --chmod=775 /home/nonroot/.local/share/uv/tools/vocalizr/bin /home/nonroot/bin
 
 EXPOSE ${GRADIO_SERVER_PORT}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apk add --no-cache build-base git
 
 USER nonroot
 
-RUN uv tool install git+https://github.com/AlphaSphereDotAI/vocalizr
+RUN uv tool install git+https://github.com/AlphaSphereDotAI/vocalizr@<commit-hash>
 
 FROM cgr.dev/chainguard/wolfi-base:latest@sha256:952010d4b1cf8dfb420ff86d66eb7ec78468b9cf60366dc8939f496322c458d8 AS production
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apk add --no-cache build-base git
 
 USER nonroot
 
-RUN uv tool install git+https://github.com/AlphaSphereDotAI/vocalizr@<commit-hash>
+RUN uv tool install git+https://github.com/AlphaSphereDotAI/vocalizr
 
 FROM cgr.dev/chainguard/wolfi-base:latest@sha256:952010d4b1cf8dfb420ff86d66eb7ec78468b9cf60366dc8939f496322c458d8 AS production
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache build-base git
 
 USER nonroot
 
-RUN uv tool install git+https://github.com/AlphaSphereDotAI/vocalizr
+RUN --mount=type=cache,target=/root/.cache/uv uv tool install git+https://github.com/AlphaSphereDotAI/vocalizr
 
 FROM cgr.dev/chainguard/wolfi-base:latest@sha256:c4136cf075c3eccea5cb7467148ad3934753d7b47e29f78963c2f056aba19643 AS production
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,6 @@ RUN apk add --no-cache build-base git
 
 USER nonroot
 
-WORKDIR /home/nonroot/app
-
 RUN uv tool install git+https://github.com/AlphaSphereDotAI/vocalizr
 
 FROM cgr.dev/chainguard/wolfi-base:latest@sha256:952010d4b1cf8dfb420ff86d66eb7ec78468b9cf60366dc8939f496322c458d8 AS production

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/wolfi-base:latest@sha256:952010d4b1cf8dfb420ff86d66eb7ec78468b9cf60366dc8939f496322c458d8 AS builder
+FROM cgr.dev/chainguard/wolfi-base:latest AS builder
 
 ENV UV_LINK_MODE=copy \
     UV_COMPILE_BYTECODE=1 \
@@ -8,24 +8,15 @@ ENV UV_LINK_MODE=copy \
 COPY --from=ghcr.io/astral-sh/uv:latest@sha256:5778d479c0fd7995fedd44614570f38a9d849256851f2786c451c220d7bd8ccd \
     /uv /uvx /usr/bin/
 
-RUN apk add --no-cache build-base
+RUN apk add --no-cache build-base git
 
 USER nonroot
 
 WORKDIR /home/nonroot/app
 
-RUN --mount=type=cache,target=/root/.cache/uv \
-    --mount=type=bind,source=uv.lock,target=uv.lock \
-    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    --mount=type=bind,source=README.md,target=README.md \
-    uv sync --no-install-project --no-dev --locked --no-editable
+RUN uv tool install git+https://github.com/AlphaSphereDotAI/vocalizr
 
-COPY . /home/nonroot/app
-
-RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --no-dev --locked --no-editable
-
-FROM cgr.dev/chainguard/wolfi-base:latest@sha256:952010d4b1cf8dfb420ff86d66eb7ec78468b9cf60366dc8939f496322c458d8 AS production
+FROM cgr.dev/chainguard/wolfi-base:latest AS production
 
 ENV GRADIO_SERVER_PORT=7860 \
     GRADIO_SERVER_NAME=0.0.0.0 \
@@ -37,10 +28,8 @@ USER nonroot
 
 WORKDIR /home/nonroot
 
-COPY --from=builder --chown=nonroot:nonroot --chmod=555 /home/nonroot/python /home/nonroot/python
-
-COPY --from=builder --chown=nonroot:nonroot --chmod=775 /home/nonroot/app/.venv /home/nonroot/app/.venv
+COPY --from=builder --chown=nonroot:nonroot --chmod=775 /home/nonroot/.local/bin /usr/bin/
 
 EXPOSE ${GRADIO_SERVER_PORT}
 
-CMD ["/home/nonroot/app/.venv/bin/vocalizr"]
+CMD ["vocalizr"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ FROM cgr.dev/chainguard/wolfi-base:latest@sha256:c4136cf075c3eccea5cb7467148ad39
 
 ENV GRADIO_SERVER_PORT=7860 \
     GRADIO_SERVER_NAME=0.0.0.0 \
-    HF_HOME=/home/nonroot/hf
+    HF_HOME=/home/nonroot/hf \
+    PATH="/home/nonroot/bin:${PATH}"
 
 RUN apk add --no-cache curl libstdc++
 
@@ -22,9 +23,7 @@ USER nonroot
 
 WORKDIR /home/nonroot
 
-RUN mkdir -p /home/nonroot/bin
-COPY --from=builder /home/nonroot/.local/bin/vocalizr /home/nonroot/bin/
-ENV PATH="/home/nonroot/bin:${PATH}"
+COPY --from=builder --chown=nonroot:nonroot --chmod=775 /home/nonroot/.local/bin/vocalizr /home/nonroot/bin/
 
 EXPOSE ${GRADIO_SERVER_PORT}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
 FROM cgr.dev/chainguard/wolfi-base:latest@sha256:c4136cf075c3eccea5cb7467148ad3934753d7b47e29f78963c2f056aba19643 AS builder
 
 COPY --from=ghcr.io/astral-sh/uv:latest@sha256:5778d479c0fd7995fedd44614570f38a9d849256851f2786c451c220d7bd8ccd \
-    /uv /uvx /usr/bin/
+     /uv /uvx /usr/bin/
 
 RUN apk add --no-cache build-base git
 
 USER nonroot
 
-RUN --mount=type=cache,target=/root/.cache/uv uv tool install git+https://github.com/AlphaSphereDotAI/vocalizr
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv tool install git+https://github.com/AlphaSphereDotAI/vocalizr
 
 FROM cgr.dev/chainguard/wolfi-base:latest@sha256:c4136cf075c3eccea5cb7467148ad3934753d7b47e29f78963c2f056aba19643 AS production
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ USER nonroot
 
 WORKDIR /home/nonroot
 
-COPY --from=builder --chown=nonroot:nonroot --chmod=775 /home/nonroot/.local/bin /usr/bin/
+COPY --from=builder /home/nonroot/.local/bin/vocalizr /usr/bin/
 
 EXPOSE ${GRADIO_SERVER_PORT}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ FROM cgr.dev/chainguard/wolfi-base:latest@sha256:c4136cf075c3eccea5cb7467148ad39
 ENV GRADIO_SERVER_PORT=7860 \
     GRADIO_SERVER_NAME=0.0.0.0 \
     HF_HOME=/home/nonroot/hf \
-    PATH="/home/nonroot/bin:${PATH}"
+    PATH=/home/nonroot/.local/bin:$PATH
 
 RUN apk add --no-cache curl libstdc++
 
@@ -23,7 +23,7 @@ USER nonroot
 
 WORKDIR /home/nonroot
 
-COPY --from=builder --chown=nonroot:nonroot --chmod=775 /home/nonroot/.local/share/uv/tools/vocalizr/bin /home/nonroot/bin
+COPY --from=builder --chown=nonroot:nonroot --chmod=755 /home/nonroot/.local/ /home/nonroot/.local/
 
 EXPOSE ${GRADIO_SERVER_PORT}
 


### PR DESCRIPTION
## Summary by Sourcery

Revamp Dockerfile into a multi-stage build that installs the vocalizr CLI directly and produces a slimmer production image.

Enhancements:
- Convert Dockerfile to multi-stage build separating builder and production stages
- In builder stage, add git and install vocalizr CLI directly via uv tool, removing Python venv and uv sync steps
- In production stage, copy only the vocalizr binary into /usr/bin and update the CMD to invoke it