### PR TITLE
Enhance Release CI/CD

### DIFF
--- a/.github/workflows/github.yaml
+++ b/.github/workflows/github.yaml
@@ -61,6 +61,7 @@ jobs:
   github_release:
     name: Create GitHub Release
     needs:
+      - details
       - setup_and_build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/github.yaml
+++ b/.github/workflows/github.yaml
@@ -1,6 +1,5 @@
 name: GitHub Release
 on:
-  workflow_dispatch:
   push:
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
@@ -23,23 +22,21 @@ jobs:
       - name: Extract tag and Details
         id: release
         run: |
-          if [ "${{ github.ref_type }}" = "tag" ]; then
-            TAG_NAME=${GITHUB_REF#refs/tags/}
-            NEW_VERSION=$(echo $TAG_NAME | awk -F'-' '{print $1}')
-            SUFFIX=$(echo $TAG_NAME | grep -oP '[a-z]+[0-9]+' || echo "")
-            echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
-            echo "suffix=$SUFFIX" >> "$GITHUB_OUTPUT"
-            echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
-            echo "Version is $NEW_VERSION"
-            echo "Suffix is $SUFFIX"
-            echo "Tag name is $TAG_NAME"
-          else
-            echo "No tag found"
-            exit 1
-          fi
+          TAG_NAME=${GITHUB_REF#refs/tags/}
+          NEW_VERSION=$(echo $TAG_NAME | awk -F'-' '{print $1}')
+          SUFFIX=$(echo $TAG_NAME | grep -oP '[a-z]+[0-9]+' || echo "")
+          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "suffix=$SUFFIX" >> "$GITHUB_OUTPUT"
+          echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
+          echo "Version is $NEW_VERSION"
+          echo "Suffix is $SUFFIX"
+          echo "Tag name is $TAG_NAME"
   setup_and_build:
     needs:
       - details
+    env:
+      UV_COMPILE_BYTECODE: "1"
+      UV_LINK_MODE: "copy"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
@@ -51,11 +48,11 @@ jobs:
           cache-dependency-glob: "uv.lock"
           activate-environment: true
       - name: Install the project
-        run: uv sync --frozen
+        run: uv sync --no-dev --frozen --no-editable
       - name: Update Project Version
         run: uv version ${{ needs.details.outputs.new_version }}
       - name: Build source and wheel distribution
-        run: uv build --all-packages
+        run: uv build
       - name: Upload artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
@@ -65,13 +62,8 @@ jobs:
     name: Create GitHub Release
     needs:
       - setup_and_build
-      - details
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          fetch-depth: 0
       - name: Download artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:

--- a/.github/workflows/github.yaml
+++ b/.github/workflows/github.yaml
@@ -11,29 +11,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 jobs:
-  details:
-    runs-on: ubuntu-latest
-    outputs:
-      new_version: ${{ steps.release.outputs.new_version }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - name: Extract tag and Details
-        id: release
-        run: |
-          TAG_NAME=${GITHUB_REF#refs/tags/}
-          NEW_VERSION=$(echo $TAG_NAME | awk -F'-' '{print $1}')
-          SUFFIX=$(echo $TAG_NAME | grep -oP '[a-z]+[0-9]+' || echo "")
-          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
-          echo "suffix=$SUFFIX" >> "$GITHUB_OUTPUT"
-          echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
-          echo "Version is $NEW_VERSION"
-          echo "Suffix is $SUFFIX"
-          echo "Tag name is $TAG_NAME"
   setup_and_build:
-    needs:
-      - details
     env:
       UV_COMPILE_BYTECODE: "1"
       UV_LINK_MODE: "copy"
@@ -50,7 +28,7 @@ jobs:
       - name: Install the project
         run: uv sync --no-dev --frozen --no-editable
       - name: Update Project Version
-        run: uv version ${{ needs.details.outputs.new_version }}
+        run: uv version ${{ github.ref_name }}
       - name: Build source and wheel distribution
         run: uv build
       - name: Upload artifacts
@@ -60,9 +38,7 @@ jobs:
           path: dist/
   github_release:
     name: Create GitHub Release
-    needs:
-      - details
-      - setup_and_build
+    needs: setup_and_build
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts
@@ -74,5 +50,5 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |-
-          gh release create ${{ needs.details.outputs.tag_name }} dist/* --title
-          ${{ needs.details.outputs.tag_name }} --generate-notes
+          gh release create ${{ github.ref_name }} dist/* --title
+          ${{ github.ref_name }} --generate-notes

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -20,7 +20,6 @@ jobs:
         with:
           name: dist
           path: dist/
-          if-no-files-found: error
       - name: Publish release distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -12,12 +12,7 @@ jobs:
       id-token: write
     environment:
       name: pypi
-      # OPTIONAL: uncomment and update to include your PyPI project URL in the deployment status:
-      # url: https://pypi.org/p/YOURPROJECT
-      #
-      # ALTERNATIVE: if your GitHub Release name is the PyPI project version string
-      # ALTERNATIVE: exactly, uncomment the following line instead:
-      # url: https://pypi.org/project/YOURPROJECT/${{ github.event.release.name }}
+      url: https://pypi.org/project/vocalizr/${{ github.event.release.name }}
     steps:
       - name: Retrieve release distributions
         uses: actions/download-artifact@v4

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -2,35 +2,14 @@ name: Upload Python Package
 on:
   release:
     types: [published]
-permissions:
-  contents: read
+permissions: read-all
 jobs:
-  release-build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.x"
-      - name: Build release distributions
-        run: |
-          # NOTE: put your own distribution build steps here.
-          python -m pip install build
-          python -m build
-      - name: Upload distributions
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-dists
-          path: dist/
   pypi-publish:
+    name: Upload Python Package
     runs-on: ubuntu-latest
-    needs:
-      - release-build
     permissions:
-      # IMPORTANT: this permission is mandatory for trusted publishing
+      contents: read
       id-token: write
-    # Dedicated environments with protections for publishing are strongly recommended.
-    # For more information, see: https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#deployment-protection-rules
     environment:
       name: pypi
       # OPTIONAL: uncomment and update to include your PyPI project URL in the deployment status:
@@ -43,9 +22,8 @@ jobs:
       - name: Retrieve release distributions
         uses: actions/download-artifact@v4
         with:
-          name: release-dists
+          name: dist
           path: dist/
-
       - name: Publish release distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -1,0 +1,52 @@
+name: Upload Python Package
+on:
+  release:
+    types: [published]
+permissions:
+  contents: read
+jobs:
+  release-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Build release distributions
+        run: |
+          # NOTE: put your own distribution build steps here.
+          python -m pip install build
+          python -m build
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+  pypi-publish:
+    runs-on: ubuntu-latest
+    needs:
+      - release-build
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+    # Dedicated environments with protections for publishing are strongly recommended.
+    # For more information, see: https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#deployment-protection-rules
+    environment:
+      name: pypi
+      # OPTIONAL: uncomment and update to include your PyPI project URL in the deployment status:
+      # url: https://pypi.org/p/YOURPROJECT
+      #
+      # ALTERNATIVE: if your GitHub Release name is the PyPI project version string
+      # ALTERNATIVE: exactly, uncomment the following line instead:
+      # url: https://pypi.org/project/YOURPROJECT/${{ github.event.release.name }}
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Publish release distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -20,6 +20,7 @@ jobs:
         with:
           name: dist
           path: dist/
+          if-no-files-found: error
       - name: Publish release distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -2,7 +2,8 @@ name: Upload Python Package
 on:
   release:
     types: [published]
-permissions: read-all
+permissions:
+  contents: read
 jobs:
   pypi-publish:
     name: Upload Python Package


### PR DESCRIPTION
## Summary by Sourcery

Streamline the GitHub Release workflow by simplifying tag extraction, refining build steps, and removing redundant actions

Enhancements:
- Remove manual workflow_dispatch trigger and unconditional ref_type check to simplify release activation
- Unify tag parsing logic by always extracting version, suffix, and tag name without branching
- Set UV_COMPILE_BYTECODE and UV_LINK_MODE env vars and refine uv sync and build commands to exclude dev and editable packages
- Omit redundant checkout in the Create GitHub Release job to reduce unnecessary steps