### PR TITLE
Use vocalizr from pypi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM cgr.dev/chainguard/wolfi-base:latest@sha256:0e09bcd548cf2dfb9a3fd40af1a7389
 COPY --from=ghcr.io/astral-sh/uv:latest@sha256:0ca07117081b2c6a8dd813d2badacf76dceecaf8b8a41d51b5d715024ffef7d8 \
      /uv /uvx /usr/bin/
 
+# skipcq: DOK-DL3018
+RUN apk add --no-cache build-base
+
 USER nonroot
 
 RUN --mount=type=cache,target=/root/.cache/uv \


### PR DESCRIPTION
This pull request updates the `Dockerfile` to simplify the build process and improve maintainability by removing the multi-stage build setup and updating dependencies. The most important changes include consolidating the build and production stages, updating the base image and `uv` tool version, and modifying the installation and execution commands for `vocalizr`.

### Dockerfile changes:

* **Consolidation of build and production stages**:
  - Removed the separate `builder` stage and merged its functionality into the `production` stage, simplifying the Dockerfile. (`[DockerfileL1-R22](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R22)`)

* **Base image update**:
  - Updated the base image from `sha256:870e094ce4118ea9dcef74f2bc4b745ad3b5439314940f02978d6fe6ef196003` to `sha256:8e512833e76aa5f49d3c2d3aee862e47abf700fca13092f56726700fc44ec91a` to use the latest version. (`[DockerfileL1-R22](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R22)`)
