### PR TITLE
fix: replace ValueError with gradio.Error for better compatibility with gradio in audio generation

### DIFF
--- a/src/vocalizr/app/builder.py
+++ b/src/vocalizr/app/builder.py
@@ -71,12 +71,12 @@ class App:
         """
         if not text:
             _msg = "No text provided"
-            logger.exception(_msg)
-            raise ValueError(_msg)
+            logger.error(_msg)
+            raise Error(_msg)
         if len(text) < 4:
             _msg = f"Text too short: {text} with length {len(text)}"
-            logger.exception(_msg)
-            raise ValueError(_msg)
+            logger.error(_msg)
+            raise Error(_msg)
 
         text: str = (
             text
@@ -90,8 +90,9 @@ class App:
         )
         for _, _, audio in generator:
             if audio is None or isinstance(audio, str):
-                logger.exception("Unexpected type (audio): %s", type(audio))
-                raise Error(message=f"Unexpected type (audio): {type(audio)}")
+                _msg = f"Unexpected type (audio): {type(audio)}"
+                logger.error(_msg)
+                raise Error(_msg)
             logger.info(
                 "Generating audio for '%s' with length %d characters",
                 text,
@@ -145,7 +146,7 @@ class App:
         """
         Save an audio array to a WAV file using the specified sampling rate.
 
-        If the saving operation fails, it logs the exception and raises a RuntimeError.
+        If the saving operation fails, it logs the exception and raises a gradio.Error.
 
         :param ndarray[tuple[float32],dtype[float32]] audio: The audio data to be saved.
             Must be a NumPy array of data type float32, representing the audio signal
@@ -161,6 +162,6 @@ class App:
             logger.info("Audio saved to %s", file_result_path)
         except Exception as e:
             _msg = f"Failed to save audio to {file_result_path}: {e}"
-            logger.exception(_msg)
-            raise RuntimeError(_msg) from e
+            logger.error(_msg)
+            raise Error(_msg) from e
         return file_result_path

--- a/src/vocalizr/app/builder.py
+++ b/src/vocalizr/app/builder.py
@@ -162,6 +162,6 @@ class App:
             logger.info("Audio saved to %s", file_result_path)
         except Exception as e:
             _msg = f"Failed to save audio to {file_result_path}: {e}"
-            logger.error(_msg)
+            logger.exception(_msg)
             raise Error(_msg) from e
         return file_result_path


### PR DESCRIPTION
## Summary by Sourcery

Use gradio.Error for all error handling in audio generation and saving functions and switch to error-level logging for better Gradio compatibility.

Enhancements:
- Replace ValueError and RuntimeError with gradio.Error in generate_audio_for_text and _save_file_wav
- Change logger.exception calls to logger.error to avoid stack traces in logs

Documentation:
- Update _save_file_wav docstring to note that gradio.Error is raised on save failures