### PR TITLE
ci: Update the tag to point to the new version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,7 +51,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # v6
         with:
           tagging_message: ${{ github.ref_name }}
-          add_options: --force
+          push_options: --force
           commit_options: --no-verify
   github_release:
     name: Create GitHub Release

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,6 +51,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # v6
         with:
           tagging_message: ${{ github.ref_name }}
+          create_git_tag_only: true
           push_options: --force
           commit_options: --no-verify
   github_release:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,12 +41,18 @@ jobs:
         with:
           name: dist
           path: dist/
-      - name: Commit updated count
+      - name: Commit updated version
         uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # v6
         with:
           commit_message: "Version: ${{ github.ref_name }}"
-          branch: main
-          commit_options: '--no-verify'
+          commit_options: --no-verify
+          file_pattern: 'pyproject.toml uv.lock'
+      - name: Update tag
+        uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # v6
+        with:
+          tagging_message: ${{ github.ref_name }}
+          add_options: --force
+          commit_options: --no-verify
   github_release:
     name: Create GitHub Release
     needs: setup_and_build


### PR DESCRIPTION
## Summary by Sourcery

Update build workflow to commit version bump files and add a step to force-update the tag to the new version

CI:
- Rename commit step to commit updated version and restrict it to pyproject.toml and uv.lock
- Add new step to force-update the repository tag to the new version using git-auto-commit-action