### PR TITLE
ci: Add force push option for version tagging

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,6 +45,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # v6
         with:
           commit_message: "Version: ${{ github.ref_name }}"
+          push_options: --force HEAD:refs/tags/${{ github.ref_name }}
           commit_options: --no-verify
           file_pattern: 'pyproject.toml uv.lock'
       - name: Update tag


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add push_options to git-auto-commit-action to force push version tags in the build workflow