### PR TITLE
ci: Fix push to tag

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,16 +45,9 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # v6
         with:
           commit_message: "Version: ${{ github.ref_name }}"
-          push_options: --force HEAD:refs/tags/${{ github.ref_name }}
+          push_options: origin --force HEAD:refs/tags/${{ github.ref_name }}
           commit_options: --no-verify
           file_pattern: 'pyproject.toml uv.lock'
-      - name: Update tag
-        uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # v6
-        with:
-          tagging_message: ${{ github.ref_name }}
-          create_git_tag_only: true
-          push_options: --force
-          commit_options: --no-verify
   github_release:
     name: Create GitHub Release
     needs: setup_and_build


### PR DESCRIPTION
Removed the update tag step and modified push options.

## Summary by Sourcery

Fix tag push step in the GitHub Actions workflow by specifying the remote and removing the redundant tag update step

CI:
- Add "origin" to push options when committing tags
- Remove obsolete "Update tag" action step