### PR TITLE
ci: Update the main branch to the updated version of `pyproject.toml`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,7 +41,14 @@ jobs:
         with:
           name: dist
           path: dist/
-      - name: Commit updated version
+      - name: Update the main to the updated version
+        uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # v6
+        with:
+          commit_message: "Version: ${{ github.ref_name }}"
+          branch: main
+          commit_options: --no-verify
+          file_pattern: 'pyproject.toml uv.lock'
+      - name: Update the tag to the updated version
         uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # v6
         with:
           commit_message: "Version: ${{ github.ref_name }}"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,7 +41,7 @@ jobs:
         with:
           name: dist
           path: dist/
-      - name: Update the main to the updated version
+      - name: Update the main branch to the updated version
         uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # v6
         with:
           commit_message: "Version: ${{ github.ref_name }}"


### PR DESCRIPTION
## Summary by Sourcery

Enhance the GitHub Actions build workflow by leveraging git-auto-commit-action to push version changes to the main branch and tag with precise configuration and improved step naming.

Enhancements:
- Configure the CI workflow to auto-commit version updates directly to the main branch with custom commit options and file patterns
- Standardize and rename CI steps for updating both the main branch and the tag version

CI:
- Update the GitHub Actions build workflow to use stefanzweifel/git-auto-commit-action@v6 with commit_message, branch, commit_options, and file_pattern parameters
- Rename the commit step to 'Update the main to the updated version' and align the tag update step name for consistency