### PR TITLE
ci: Update the way of updating tag

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,7 +51,8 @@ jobs:
       - name: Update the tag to the updated version
         uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # v6
         with:
-          commit_message: "Version: ${{ github.ref_name }}"
+          tagging_message: ${{ github.ref_name }}
+          create_git_tag_only: true
           push_options: origin --force HEAD:refs/tags/${{ github.ref_name }}
           commit_options: --no-verify
           file_pattern: 'pyproject.toml uv.lock'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,8 +54,6 @@ jobs:
           tagging_message: ${{ github.ref_name }}
           create_git_tag_only: true
           push_options: origin --force HEAD:refs/tags/${{ github.ref_name }}
-          commit_options: --no-verify
-          file_pattern: 'pyproject.toml uv.lock'
   github_release:
     name: Create GitHub Release
     needs: setup_and_build


### PR DESCRIPTION
## Summary by Sourcery

Refine the CI build workflow’s tagging step to use the git-auto-commit-action’s tagging_message parameter and enable tag-only creation

CI:
- Replace commit_message with tagging_message parameter in the git-auto-commit-action
- Enable create_git_tag_only option to only create tags without committing files