### PR TITLE
ci: Update tag updating method in build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,10 +48,9 @@ jobs:
           branch: main
           commit_options: --no-verify
       - name: Update the tag to the updated version
-        uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # v6
-        with:
-          tagging_message: ${{ github.ref_name }}
-          push_options: origin --force HEAD:refs/tags/${{ github.ref_name }}
+        run: |
+          git tag ${{ github.ref_name }}
+          git push origin --force HEAD:refs/tags/${{ github.ref_name }}
   github_release:
     name: Create GitHub Release
     needs: setup_and_build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,7 +49,7 @@ jobs:
           commit_options: --no-verify
       - name: Update the tag to the updated version
         run: |
-          git tag ${{ github.ref_name }}
+          git tag --force ${{ github.ref_name }}
           git push origin --force HEAD:refs/tags/${{ github.ref_name }}
   github_release:
     name: Create GitHub Release


### PR DESCRIPTION
Replaced git-auto-commit-action with manual git tag command.

## Summary by Sourcery

CI:
- Replace git-auto-commit-action with manual git tag and force-push in the build workflow