### PR TITLE
fix: add permissions for contents in build job and remove redundant token usage

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Setup and Build
     environment:
       name: uv
-      url: https://github.com/${{github.repository}}/commits/${{github.ref_name}}
+      url: ${{github.event.repository.html_url}}/commits/${{github.ref_name}}
     env:
       UV_COMPILE_BYTECODE: "1"
       UV_LINK_MODE: "copy"
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: github
-      url: https://github.com/${{github.repository}}/releases/tag/${{github.ref_name}}
+      url: ${{github.event.repository.html_url}}/releases/tag/${{github.ref_name}}
     steps:
       - name: Checkout Code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,12 +18,12 @@ jobs:
     env:
       UV_COMPILE_BYTECODE: "1"
       UV_LINK_MODE: "copy"
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
-        with:
-          token: ${{ secrets.GH_TOKEN }}
       - name: Install uv
         uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4 # v6
         with:


### PR DESCRIPTION
## Summary by Sourcery

Update build workflow to grant write access, streamline checkout, and correct environment URLs

Enhancements:
- Grant contents write permission in the build job
- Remove redundant explicit token from actions/checkout step
- Use event.repository.html_url for environment URLs instead of hardcoded repository path