### PR TITLE
Use GH_TOKEN

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
-          token: ${{ secrets.GH_TOKEN_REPO }}
+          token: ${{ secrets.GH_TOKEN }}
       - name: Install uv
         uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4 # v6
         with:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Switch actions/checkout token from GH_TOKEN_REPO to GH_TOKEN