### PR TITLE
ci: Remove docker cache

### DIFF
--- a/.github/workflows/.docker.yaml
+++ b/.github/workflows/.docker.yaml
@@ -91,8 +91,6 @@ jobs:
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
         id: push
         with:
-          cache-from: ${{ inputs.is_test && 'type=gha' || '' }}
-          cache-to: ${{ inputs.is_test && 'type=gha,mode=max' || '' }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Removed cache-from and cache-to options for Docker build.

## Summary by Sourcery

CI:
- Remove cache-from and cache-to options from Docker build in CI workflow